### PR TITLE
Improved the Meal Plan page design

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,11 @@ class CulinaryCompanionApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'Culinary Companion',
       theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Color(0xFFDC945F), // Replace this with your seed color
+          brightness: Brightness.light, // or Brightness.dark for dark theme
+        ),
+        useMaterial3: true,
         textTheme: GoogleFonts.interTextTheme(),
         primarySwatch: Colors.green,
         brightness: Brightness.light,
@@ -56,6 +61,10 @@ class CulinaryCompanionApp extends StatelessWidget {
         ),
       ),
       darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Color(0xFFEDEDED), // Replace this with your seed color
+          brightness: Brightness.dark, // or Brightness.dark for dark theme
+        ),
         textTheme: GoogleFonts.interTextTheme().apply(
           bodyColor: Color(0xFFD9D9D9),
           displayColor: Color(0xFFD9D9D9),

--- a/lib/widgets/generate_meal_plan_screen.dart
+++ b/lib/widgets/generate_meal_plan_screen.dart
@@ -22,6 +22,14 @@ class GenerateMealPlanState extends State<GenerateMealPlanScreen> {
   int _activityLevel = 1;
   String? _goal;
   int _mealFrequency = 3;
+  List<String> _mealTypes = [
+    'Breakfast',
+    'Lunch',
+    'Dinner',
+    'Appetizer',
+    'Dessert'
+  ];
+  List<String> _selectedMeals = [];
 
   @override
   Widget build(BuildContext context) {
@@ -298,7 +306,10 @@ class GenerateMealPlanState extends State<GenerateMealPlanScreen> {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Activity Level:'),
+                  Text(
+                    'Activity Level:',
+                    style: TextStyle(fontSize: 16),
+                  ),
                   SizedBox(height: 16),
                   Slider(
                     value: _activityLevel.toDouble(),
@@ -366,12 +377,14 @@ class GenerateMealPlanState extends State<GenerateMealPlanScreen> {
                 onChanged: (value) {},
               ),
               const SizedBox(height: 16),
-              // Dietary Preferences - get this from database, no need to enter again
               // Meal Frequency - Slider
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Preferred Meal Frequency (meals/day):'),
+                  Text(
+                    'Preferred Meal Frequency (meals/day):',
+                    style: TextStyle(fontSize: 16),
+                  ),
                   SizedBox(height: 16),
                   Slider(
                     value: _mealFrequency.toDouble(),
@@ -383,10 +396,54 @@ class GenerateMealPlanState extends State<GenerateMealPlanScreen> {
                       if (mounted) {
                         setState(() {
                           _mealFrequency = value.toInt();
+                          _selectedMeals
+                              .clear(); //Clear selected meals when frequency changes
                         });
                       }
                     },
                     activeColor: Color(0xFFDC945F),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              // Meal Type Checkboxes in a Row
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Select Meal Types:',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                  SizedBox(height: 16),
+                  Wrap(
+                    spacing: 100.0,
+                    runSpacing: 4.0,
+                    children: _mealTypes.map((mealType) {
+                      return Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Checkbox(
+                            value: _selectedMeals.contains(mealType),
+                            onChanged: _selectedMeals.length < _mealFrequency ||
+                                    _selectedMeals.contains(mealType)
+                                ? (bool? value) {
+                                    setState(() {
+                                      if (value == true) {
+                                        _selectedMeals.add(mealType);
+                                      } else {
+                                        _selectedMeals.remove(mealType);
+                                      }
+                                    });
+                                  }
+                                : null, // Disable if limit is reached
+                          ),
+                          Text(
+                            mealType,
+                            style: TextStyle(fontSize: 16),
+                          ),
+                        ],
+                      );
+                    }).toList(),
                   ),
                 ],
               ),
@@ -404,6 +461,7 @@ class GenerateMealPlanState extends State<GenerateMealPlanScreen> {
                     print("Activity Level: $_activityLevel");
                     print("Goal: $_goal");
                     print("Meal Frequency: $_mealFrequency");
+                    print("Selected Meals: $_selectedMeals");
 
                     // Show loading dialog with Lottie animation
                     showDialog(

--- a/lib/widgets/my_meal_plans_screen.dart
+++ b/lib/widgets/my_meal_plans_screen.dart
@@ -44,6 +44,10 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final bool isLightTheme = Theme.of(context).brightness == Brightness.light;
+    final Color backgroundColor =
+        isLightTheme ? Colors.white : Color.fromARGB(255, 52, 68, 64);
+
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
@@ -76,6 +80,7 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
             },
             children: mealPlans.map<ExpansionPanel>((mealPlan) {
               return ExpansionPanel(
+                backgroundColor: backgroundColor,
                 headerBuilder: (BuildContext context, bool isExpanded) {
                   return ListTile(
                     title: Text(
@@ -87,8 +92,10 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
                     ),
                   );
                 },
-                body: buildMealPlanContent(mealPlan['days']
-                    as Map<String, List<Map<String, dynamic>>>),
+                body: buildMealPlanContent(
+                  mealPlan['days'] as Map<String, List<Map<String, dynamic>>>,
+                  context,
+                ),
                 isExpanded: mealPlan['isExpanded'],
               );
             }).toList(),
@@ -98,13 +105,25 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
     );
   }
 
-  Widget buildMealPlanContent(Map<String, List<Map<String, dynamic>>> days) {
+  Widget buildMealPlanContent(
+      Map<String, List<Map<String, dynamic>>> days, BuildContext context) {
+    // Determine the screen width
+    double screenWidth = MediaQuery.of(context).size.width;
+
+    // Define card dimensions based on screen size
+    double cardWidth = screenWidth > 600
+        ? 300
+        : 150; // 300 for larger screens, 150 for smaller screens
+    double cardHeight = screenWidth > 600
+        ? 400
+        : 200; // 400 for larger screens, 200 for smaller screens
+
     return Column(
       children: days.entries.map((entry) {
         String day = entry.key;
         List<Map<String, dynamic>> recipes = entry.value;
         return Padding(
-          padding: const EdgeInsets.all(30),
+          padding: const EdgeInsets.all(25),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -139,31 +158,36 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
                     children: [
                       ...recipes.map((recipe) {
                         return Padding(
-                          padding: const EdgeInsets.only(right: 8.0),
-                          child: RecipeCard(
-                            recipeID: recipe['recipeId'] ?? '',
-                            name: recipe['name'] ?? 'Recipe Name',
-                            description:
-                                recipe['description'] ?? 'Description here',
-                            imagePath: recipe['photo'] ??
-                                'assets/placeholder_image.jpg',
-                            prepTime: recipe['preptime'] ?? 0,
-                            cookTime: recipe['cooktime'] ?? 0,
-                            cuisine: recipe['cuisine'] ?? 'Cuisine',
-                            spiceLevel: recipe['spicelevel'] ?? 0,
-                            course: recipe['course'] ?? 'Main Course',
-                            servings: recipe['servings'] ?? 1,
-                            steps: ['Step 1', 'Step 2'],
-                            appliances: ['Oven', 'Stove'],
-                            ingredients: [
-                              {'name': 'Ingredient 1', 'quantity': '100g'}
-                            ],
-                          ),
-                        );
+                            padding: const EdgeInsets.only(right: 8.0),
+                            child: SizedBox(
+                              width: cardWidth,
+                              height: cardHeight,
+                              child: RecipeCard(
+                                recipeID: recipe['recipeId'] ?? '',
+                                name: recipe['name'] ?? 'Recipe Name',
+                                description:
+                                    recipe['description'] ?? 'Description here',
+                                imagePath: recipe['photo'] ??
+                                    'assets/placeholder_image.jpg',
+                                prepTime: recipe['preptime'] ?? 0,
+                                cookTime: recipe['cooktime'] ?? 0,
+                                cuisine: recipe['cuisine'] ?? 'Cuisine',
+                                spiceLevel: recipe['spicelevel'] ?? 0,
+                                course: recipe['course'] ?? 'Main Course',
+                                servings: recipe['servings'] ?? 1,
+                                steps: ['Step 1', 'Step 2'],
+                                appliances: ['Oven', 'Stove'],
+                                ingredients: [
+                                  {'name': 'Ingredient 1', 'quantity': '100g'}
+                                ],
+                              ),
+                            ));
                       }).toList(),
                       if (recipes.isEmpty)
-                        ...List.generate(3, (index) => PlaceholderRecipeCard())
-                            .toList(),
+                        ...List.generate(
+                            3,
+                            (index) => PlaceholderRecipeCard(
+                                width: cardWidth, height: cardHeight)).toList(),
                     ],
                   ),
                 ),
@@ -177,11 +201,16 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
 }
 
 class PlaceholderRecipeCard extends StatelessWidget {
+  final double width;
+  final double height;
+
+  PlaceholderRecipeCard({required this.width, required this.height});
+
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 150 * 2,
-      height: 200 * 2,
+      width: width,
+      height: height,
       margin: EdgeInsets.only(right: 10),
       decoration: BoxDecoration(
         color: Colors.grey[200],

--- a/lib/widgets/my_meal_plans_screen.dart
+++ b/lib/widgets/my_meal_plans_screen.dart
@@ -50,7 +50,7 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
         backgroundColor: Colors.transparent,
         elevation: 0,
         title: Padding(
-          padding: EdgeInsets.only(top: 30, left: 38.0),
+          padding: EdgeInsets.all(30),
           child: Text(
             'My Meal Plans',
             style: TextStyle(
@@ -104,7 +104,7 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
         String day = entry.key;
         List<Map<String, dynamic>> recipes = entry.value;
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 12.0),
+          padding: const EdgeInsets.all(30),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -162,7 +162,7 @@ class _MyMealPlanScreenState extends State<MyMealPlansScreen> {
                         );
                       }).toList(),
                       if (recipes.isEmpty)
-                        ...List.generate(2, (index) => PlaceholderRecipeCard())
+                        ...List.generate(3, (index) => PlaceholderRecipeCard())
                             .toList(),
                     ],
                   ),
@@ -180,8 +180,8 @@ class PlaceholderRecipeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 150,
-      height: 200,
+      width: 150 * 2,
+      height: 200 * 2,
       margin: EdgeInsets.only(right: 10),
       decoration: BoxDecoration(
         color: Colors.grey[200],


### PR DESCRIPTION
# Improve the Meal Plan Page design

### Related issue/feature
#393 
#394

### Description of introduced fix/feature
1. Minimized space on My meal plans page by adding some padding and making background colour for dark mode lighter
2. Adjusted placeholder recipe card size based on user's screen size
3. Fixed purple default seed colour
4. Added options for user to select which meals they want in their meal plan.

### Mentions of people responsible for reviewing the pull request
@u21463230 